### PR TITLE
Include protobuf dependency and make the voxelizer build on other machines.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(Qt5Gui REQUIRED)
 find_package(Qt5OpenGL REQUIRED)
 find_package(GLEW REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem system)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf 3.4.0 EXACT REQUIRED)
 
 find_package(catkin COMPONENTS 
      glow)

--- a/README.md
+++ b/README.md
@@ -21,12 +21,21 @@ Use tfrecord converter in a second step to generate final tfrecords for training
 * OpenGL >= 3.3
 * [glow](https://github.com/jbehley/glow) (catkin package)
 * libmatio-dev
+* protobuf == 3.4.0
  
 ## Build
   
 On Ubuntu 16.04, most of the dependencies can be installed from the package manager:
 ```bash
 sudo apt install git libeigen3-dev libboost-all-dev qtbase5-dev libglew-dev catkin libmatio-dev
+```
+
+Install protobuf 3.4.0:
+[Download the sources](https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.4.0.zip) and unpack them.
+Follow [the offical guide](https://github.com/protocolbuffers/protobuf/blob/master/src/README.md) to compile and install it.
+The version can be checked with 
+```bash
+protoc --version
 ```
 
 Use a python-2 conda env.


### PR DESCRIPTION
The voxelizer requires exactly version 3.4.0 of protobuf. 
For future reference [this](https://stackoverflow.com/questions/52040428/how-to-update-protobuf-runtime-library) and [this](https://stackoverflow.com/questions/35744529/protocol-buffer-error-on-compile-during-google-protobuf-min-protoc-version-check) are helpful issues to solve any problems during the installation process.

